### PR TITLE
Install SticsRFiles from CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     grDevices,
     magrittr,
     rstudioapi,
-    SticsRFiles,
+    SticsRFiles (>= 1.1.3),
     SticsOnR,
     CroptimizR,
     CroPlotR,
@@ -42,7 +42,6 @@ Imports:
 	tictoc,
 	lifecycle
 Remotes:
-    github::SticsRPacks/SticsRFiles@*release,
     github::SticsRPacks/SticsOnR@*release,
     github::SticsRPacks/CroptimizR@*release,
     github::SticsRPacks/CroPlotR@*release


### PR DESCRIPTION
fix DESCRIPTION file adding  SticsRFiles (>= 1.1.3) in imports section and removing github release from remotes.