### PR TITLE
Update check-standard.yaml

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -42,6 +42,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: r-hub/actions/setup-r-sysreqs@v1 # Install and setup R system dependencies on macOS.
+        with:
+          type: full
 
       - uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
install of dependency tools for R under macos