### PR TITLE
fix update-citation-cff.yaml

### DIFF
--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -29,6 +29,9 @@ jobs:
           extra-packages: |
             any::cffr
             any::V8
+      - name: install getext
+        run: |
+          sudo port install gettext
       - name: Update CITATION.cff
         run: |
           library(cffr)


### PR DESCRIPTION
try installing gettext on MacOS

The missing libintl.h file is provided by the system package `gettext` added in the yaml file 